### PR TITLE
solved "no-string-literal" error

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "tslint:recommended",
   "rules": {
+    "no-string-literal": false,
     "array-type": false,
     "arrow-parens": false,
     "deprecation": {


### PR DESCRIPTION
1. 에러 내용: 프로퍼티에 string 값 입력 시 "object access via string literals is disallowed (no-string-literal)" 에러 발생
2. 해결: tslint.json 파일에 "no-string-literal": false 입력

물론 변경하지 않아도 실행에 아무런 문제가 없습니다.